### PR TITLE
Defer terraform destroy prior to invoking terraform apply. This fixes…

### DIFF
--- a/test-harness/infratests/integration.go
+++ b/test-harness/infratests/integration.go
@@ -50,8 +50,8 @@ func RunIntegrationTests(fixture *IntegrationTestFixture) {
 	defer terraform.RunTerraformCommand(fixture.GoTest, fixture.TfOptions, "workspace", "delete", workspaceName)
 	defer terraform.WorkspaceSelectOrNew(fixture.GoTest, fixture.TfOptions, "default")
 
-	terraform.Apply(fixture.GoTest, fixture.TfOptions)
 	defer terraform.Destroy(fixture.GoTest, fixture.TfOptions)
+	terraform.Apply(fixture.GoTest, fixture.TfOptions)
 
 	output := terraform.OutputAll(fixture.GoTest, fixture.TfOptions)
 	validateTerraformOutput(fixture, TerraformOutput(output))


### PR DESCRIPTION
… an issue where destroy() was never called in the case that the apply() failed (#157)

## All Submissions:
-------------------------------------
* [YES/NO] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES/NO] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES/NO] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] My code follows the code style of this project.
* [YES/NO/NA] I ran lint checks locally prior to submission.
* [YES/NO] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
-------------------------------------
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?
-------------------------------------
- [YES/NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
